### PR TITLE
Fixed typo in `filePath`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Fixed typo`Filepath` becomes `filePath` in Android SDK.
+
 ## 0.0.1
 
 - Initial release of SDK support for Capacitor / IONIC.

--- a/android/src/main/java/com/klippa/capacitorscanner/KlippaScannerSDKPlugin.kt
+++ b/android/src/main/java/com/klippa/capacitorscanner/KlippaScannerSDKPlugin.kt
@@ -250,7 +250,7 @@ class KlippaScannerSDKPlugin : Plugin() {
             val images: MutableList<Map<String, String>> = mutableListOf()
 
             for (image in receivedImages) {
-                val imageDict = mapOf("Filepath" to image.filePath)
+                val imageDict = mapOf("filepath" to image.filePath)
                 images.add(imageDict)
             }
 

--- a/android/src/main/java/com/klippa/capacitorscanner/KlippaScannerSDKPlugin.kt
+++ b/android/src/main/java/com/klippa/capacitorscanner/KlippaScannerSDKPlugin.kt
@@ -250,7 +250,7 @@ class KlippaScannerSDKPlugin : Plugin() {
             val images: MutableList<Map<String, String>> = mutableListOf()
 
             for (image in receivedImages) {
-                val imageDict = mapOf("filepath" to image.filePath)
+                val imageDict = mapOf("filePath" to image.filePath)
                 images.add(imageDict)
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klippa/capacitor-klippa-scanner-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Capacitor plugin for Ionic to use the Klippa Scanner SDK",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
In the Android SDK the `CameraResultImage` typing was incorrectly typed as `Filepath` where it should be `filePath` to match iOS and the typings in the `index.tsx`